### PR TITLE
BUG FIX: Incorrect arg count for init action

### DIFF
--- a/pmpro-variable-prices.php
+++ b/pmpro-variable-prices.php
@@ -267,13 +267,12 @@ add_action("pmpro_paypalexpress_session_vars", "pmprovp_pmpro_paypalexpress_sess
 add_action("pmpro_before_send_to_twocheckout", "pmprovp_pmpro_paypalexpress_session_vars", 10, 2);
 
 //Load fields from session if available.
-function pmprovp_init_load_session_vars($param)
+function pmprovp_init_load_session_vars()
 {
 	if(empty($_REQUEST['price']) && !empty($_SESSION['price']))
 	{
 		$_REQUEST['price'] = $_SESSION['price'];
 	}
-	return $param;
 }
 add_action('init', 'pmprovp_init_load_session_vars', 5);
 


### PR DESCRIPTION
May have caused issues when returning from PayPal (init handler not executing)