### PR TITLE
BUG FIX: JS Loads On Every Page

### DIFF
--- a/pmpro-variable-pricing.php
+++ b/pmpro-variable-pricing.php
@@ -321,7 +321,7 @@ function pmprovp_load_scripts() {
 	
 	$var_pricing = pmprovp_get_settings( $pmpro_level->id );
 	
-	// Bail if no variable pricing is not enabled.
+	// Bail if variable pricing is not enabled.
 	if( 0 === $var_pricing['variable_pricing'] ) {
 		return;
 	}
@@ -352,7 +352,7 @@ function pmprovp_enqueue_scripts() {
 
 	$var_pricing = pmprovp_get_settings( $pmpro_level->id );
 	
-	// Bail if no variable pricing is not enabled.
+	// Bail if variable pricing is not enabled.
 	if( 0 === $var_pricing['variable_pricing'] ) {
 		return;
 	}

--- a/pmpro-variable-pricing.php
+++ b/pmpro-variable-pricing.php
@@ -309,15 +309,21 @@ add_action( 'init', 'pmprovp_init_load_session_vars', 5 );
  */
 function pmprovp_load_scripts() {
 
-	global $gateway;
+	global $gateway, $pmpro_level, $pmpro_pages;
 
-	// Bail if PMPro is not loaded.
-	if ( ! function_exists( 'pmpro_getOption' ) ) {
+	if ( ! is_page( $pmpro_pages['checkout'] ) ) {
 		return;
 	}
 
 	if ( empty( $gateway ) ) {
 		$gateway = pmpro_getOption( 'gateway' );
+	}
+	
+	$var_pricing = pmprovp_get_settings( $pmpro_level->id );
+	
+	// Bail if no variable pricing is not enabled.
+	if( 0 === $var_pricing['variable_pricing'] ) {
+		return;
 	}
 
 	wp_register_script( 'pmprovp', plugins_url( 'javascript/pmpro-variable-pricing.js', __FILE__ ), array( 'jquery' ), '0.4', true );
@@ -338,6 +344,18 @@ add_action( 'wp_enqueue_scripts', 'pmprovp_load_scripts', 5 );
  * Split register/localize and enqueue operation to simplify unhooking JS from plugin if needed
  */
 function pmprovp_enqueue_scripts() {
+	global $pmpro_level, $pmpro_pages;
+
+	if ( ! is_page( $pmpro_pages['checkout'] ) ) {
+		return;
+	}
+
+	$var_pricing = pmprovp_get_settings( $pmpro_level->id );
+	
+	// Bail if no variable pricing is not enabled.
+	if( 0 === $var_pricing['variable_pricing'] ) {
+		return;
+	}
 
 	wp_enqueue_script( 'pmprovp' );
 }


### PR DESCRIPTION
BUG FIX: Javascript for Variable Pricing Add On would load on every page and it would load on the checkout page even when the Variable Pricing Option was disabled.

Added in checks to only load if the setting is enabled and if the current page is the checkout page.