### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/pmpro-variable-pricing.php
+++ b/pmpro-variable-pricing.php
@@ -41,12 +41,9 @@ function pmprovp_get_settings( $level_id ) {
 		'suggested_price'  => '',
 	);
 
-	if ( ! empty( $level_id) ) {
-		$settings = get_option( "pmprovp_{$level_id}", $defaults );
-		$settings = array_merge( $defaults, $settings );  // make sure newly added settings have defaults appended
-	}
+	$existing_settings = empty( $level_id ) ? array() : get_option( "pmprovp_{$level_id}", array() );
 
-	return $settings;
+	return array_merge( $defaults, $existing_settings );
 }
 
 /*

--- a/pmpro-variable-pricing.php
+++ b/pmpro-variable-pricing.php
@@ -40,8 +40,11 @@ function pmprovp_get_settings( $level_id ) {
 		'max_price'        => '',
 		'suggested_price'  => '',
 	);
-	$settings = get_option( "pmprovp_{$level_id}", $defaults );
-	$settings = array_merge( $defaults, $settings );  // make sure newly added settings have defaults appended
+
+	if ( ! empty( $level_id) ) {
+		$settings = get_option( "pmprovp_{$level_id}", $defaults );
+		$settings = array_merge( $defaults, $settings );  // make sure newly added settings have defaults appended
+	}
 
 	return $settings;
 }
@@ -342,7 +345,8 @@ function pmprovp_pmpro_registration_checks( $continue ) {
 		// was a price passed in?
 		if ( isset( $_REQUEST['price'] ) ) {
 			// get values
-			$level_id = intval( $_REQUEST['level'] );
+			$level    = pmpro_getLevelAtCheckout();
+			$level_id = empty( $level->id ) ? null : intval( $level->id );
 			$vpfields = pmprovp_get_settings( $level_id );
 
 			// Bail if the Variable Pricing is not set for this level.


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_getLevelAtCheckout()` function.