### PR TITLE
[BUGFIXING] The Variable Pricing Add On generates a warning

### DIFF
--- a/pmpro-variable-pricing.php
+++ b/pmpro-variable-pricing.php
@@ -124,7 +124,10 @@ add_action( 'pmpro_membership_level_after_other_settings', 'pmprovp_pmpro_member
 
 // save level cost text when the level is saved/added
 function pmprovp_pmpro_save_membership_level( $level_id ) {
-	$variable_pricing = intval( $_REQUEST['variable_pricing'] );
+	$variable_pricing =	0;
+	if ( isset( $_REQUEST['variable_pricing'] ) ) {
+		$variable_pricing = intval( $_REQUEST['variable_pricing'] );
+	}
 	$min_price        = preg_replace( '[^0-9\.]', '', $_REQUEST['min_price'] );
 	$max_price        = preg_replace( '[^0-9\.]', '', $_REQUEST['max_price'] );
 	$suggested_price  = preg_replace( '[^0-9\.]', '', $_REQUEST['suggested_price'] );
@@ -306,6 +309,10 @@ add_action( 'pmpro_checkout_after_level_cost', 'pmprovp_pmpro_checkout_after_lev
 
 // set price
 function pmprovp_pmpro_checkout_level( $level ) {
+	//Bail if level object is empty.
+	if ( empty( $level->id ) ) {
+		return $level;
+	}
 	// Get variable pricing info.
 	$vpfields = pmprovp_get_settings( $level->id );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Check the `$_REQUEST['variable_pricing']` isset before access it at the top of `pmpro_save_membership_level` callback function
Bail if $level->id is empty at the top of the `pmpro_checkout_level` callback function


### How to test the changes in this Pull Request:

1. Without this patch, enable this  Add On, go to level settings page and save it without filling variable pricing related data.
2. Check the logs.
3. Apply the patch and repeat steps above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
