### PR TITLE
Resolve deprecation warnings on PHP 8.5+

### DIFF
--- a/pmpro-variable-pricing.php
+++ b/pmpro-variable-pricing.php
@@ -508,7 +508,7 @@ function pmprovp_pmpro_registration_checks( $continue ) {
 			$price = preg_replace( '[^0-9\.]', '', floatval( $_REQUEST['price'] ) );
 
 			// check that the price falls between the min and max
-			if ( (double) $price < (double) $vpfields['min_price'] ) {
+			if ( (float) $price < (float) $vpfields['min_price'] ) {
 				$pmpro_msg  = sprintf(
 					__( 'The lowest accepted price is %1$s%2$s. Please enter a new amount.', 'pmpro-variable-pricing' ),
 					esc_html( $pmpro_currency_symbol ),
@@ -516,7 +516,7 @@ function pmprovp_pmpro_registration_checks( $continue ) {
 				);
 				$pmpro_msgt = 'pmpro_error';
 				$continue   = false;
-			} elseif ( ! empty( $vpfields['max_price'] ) && ( (double) $price > (double) $vpfields['max_price'] ) ) {
+			} elseif ( ! empty( $vpfields['max_price'] ) && ( (float) $price > (float) $vpfields['max_price'] ) ) {
 				$pmpro_msg  = sprintf(
 					__( 'The highest accepted price is %1$s%2$s. Please enter a new amount.', 'pmpro-variable-pricing' ),
 					esc_html( $pmpro_currency_symbol ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-variable-pricing/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-variable-pricing/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Cast names (boolean), (integer), (double), and (binary) have been [deprecated in PHP 8.5](https://www.php.net/manual/en/migration85.deprecated.php).

Updating (double) cast name to (float).

Resolves notice `Non-canonical cast (double) is deprecated, use the (float) cast instead`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed a PHP deprecation warning that may show on sites running PHP 8.5+.
